### PR TITLE
feature: 공개 플랜 목록 조회 API 구현 (#29)

### DIFF
--- a/src/main/java/com/ssafy/trabuddy/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/ssafy/trabuddy/domain/plan/controller/PlanController.java
@@ -5,19 +5,27 @@ import com.ssafy.trabuddy.domain.plan.model.dto.AddPlanRequest;
 import com.ssafy.trabuddy.domain.plan.model.dto.GetPlanResponse;
 import com.ssafy.trabuddy.domain.plan.model.dto.UpdatePlanRequest;
 import com.ssafy.trabuddy.domain.plan.service.PlanService;
+import com.ssafy.trabuddy.domain.planLike.model.dto.PlanLikeResponse;
+import com.ssafy.trabuddy.domain.planLike.service.PlanLikeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class PlanController {
     private final PlanService planService;
+    private final PlanLikeService planLikeService;
 
     @PostMapping("/v1/plans")
-    public ResponseEntity<GetPlanResponse> getPlan(@Valid @RequestBody AddPlanRequest request, @AuthenticationPrincipal LoggedInMember loggedInMember) {
+    public ResponseEntity<GetPlanResponse> addPlan(@Valid @RequestBody AddPlanRequest request, @AuthenticationPrincipal LoggedInMember loggedInMember) {
         GetPlanResponse response = planService.addPlan(request, loggedInMember);
         return ResponseEntity.ok(response);
     }
@@ -31,6 +39,36 @@ public class PlanController {
     @PatchMapping("/v1/plans/{planId}")
     public ResponseEntity<GetPlanResponse> updatePlan(@PathVariable long planId, @Valid @RequestBody UpdatePlanRequest request) {
         GetPlanResponse response = planService.updatePlan(planId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 공개 플랜 목록 조회 (OPEN 상태인 다른 사람의 플랜)
+     */
+    @GetMapping("/v1/plans")
+    public ResponseEntity<List<GetPlanResponse>> getOpenPlans() {
+        log.info("PlanController - getOpenPlans 요청");
+        List<GetPlanResponse> response = planService.getOpenPlans();
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 플랜 좋아요/취소 토글
+     * 현재 좋아요 상태를 확인하여 자동으로 토글 (좋아요 ↔ 취소)
+     */
+    @PostMapping("/v1/plans/{planId}/like")
+    public ResponseEntity<PlanLikeResponse> togglePlanLike(@PathVariable Long planId) {
+        log.info("PlanController - togglePlanLike 요청 - planId: {}", planId);
+        
+        // SecurityContext에서 인증된 사용자 정보 가져오기
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof LoggedInMember)) {
+            log.error("인증되지 않은 사용자의 좋아요 요청");
+            return ResponseEntity.status(401).build();
+        }
+        
+        LoggedInMember loggedInMember = (LoggedInMember) authentication.getPrincipal();
+        PlanLikeResponse response = planLikeService.togglePlanLike(planId, loggedInMember);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ssafy/trabuddy/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/com/ssafy/trabuddy/domain/plan/repository/PlanRepository.java
@@ -1,5 +1,6 @@
 package com.ssafy.trabuddy.domain.plan.repository;
 
+import com.ssafy.trabuddy.domain.plan.enums.PlanVisibility;
 import com.ssafy.trabuddy.domain.plan.model.entity.PlanEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +8,9 @@ import java.util.List;
 
 public interface PlanRepository extends JpaRepository<PlanEntity, Long> {
     List<PlanEntity> findByDeletedAtIsNullAndOwnerId(long ownerId);
+    
+    /**
+     * 특정 visibility와 삭제되지 않은 플랜 조회
+     */
+    List<PlanEntity> findByVisibilityAndDeletedAtIsNull(PlanVisibility visibility);
 }


### PR DESCRIPTION
## Issue Number

- #29 

## Summary

- open으로 설정된 계획들만 조회 가능

## Description

어떤 변경 사항이 있나요?

- [x] PlanRepository에 visibility 기반 조회 메서드 추가
- [x] PlanService에 공개 플랜 조회 로직 구현
- [x] GET /v1/plans 엔드포인트 구현 (OPEN 상태 플랜만 조회)

close #29 
